### PR TITLE
add reference option for all create and add commands

### DIFF
--- a/lib/Git/ReleaseRepo/CreateCommand.pm
+++ b/lib/Git/ReleaseRepo/CreateCommand.pm
@@ -41,6 +41,7 @@ around opt_spec => sub {
     return (
         $self->$orig,
         [ 'version_prefix:s' => 'Set the version prefix of the release repository' ],
+        [ 'reference_root=s' => 'Specify a directory containing existing submodules to reference' ],
     );
 };
 


### PR DESCRIPTION
When creating release repositories in my development environment I've found it helpful to pass the `--reference` option to git submodule 'add' and 'update' commands (see git [documentation](http://git-scm.com/docs/git-submodule)) to hard-link objects from a local clone of a sub-module, rather than recopying them from an origin. This makes things a lot more efficient than duplicating modules when I typically already have a clone on disk for local development.

The git documentation cautions against referencing local clones where natural branch progression might result in garbage collection of referenced objects, however the general concept and usage of release repositories seems to preclude this.

I've come up with a `--reference_root` option to signify to git release commands that submodules should be referenced from a specified root directory. This pertains specifically to the following release "create" commands:
- clone
- deploy
- add

The tests can verify this functionality by checking for the existence of a `.git/modules/<name>/objects/info/alternates` file as per the git documentation.

Right now this functionality assumes the existence of the reference repository on disk (and that it is local, i.e. not mounted) and git will complain if otherwise. I could enhance the error handling to catch this earlier on (and possibly recover gracefully) but for now everything seems to work.
